### PR TITLE
Add encoding as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3047,6 +3047,14 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -3742,7 +3750,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -7700,8 +7707,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test-watch": "npm test -- --watchAll"
   },
   "dependencies": {
+    "encoding": "^0.1.12",
     "isomorphic-unfetch": "^3.0.0"
   },
   "devDependencies": {

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -18,6 +18,7 @@ import fetch from 'isomorphic-unfetch';
  *    }
  */
 function request(url, options) {
+  console.log('🌐 request:', { url, options });
   return new Promise((resolve, reject) => {
     fetch(url, options)
       .then(handleResponse)

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -18,7 +18,6 @@ import fetch from 'isomorphic-unfetch';
  *    }
  */
 function request(url, options) {
-  console.log('🌐 request:', { url, options });
   return new Promise((resolve, reject) => {
     fetch(url, options)
       .then(handleResponse)


### PR DESCRIPTION
This is a temporary workaround for a Rollup warning encountered when building downstream projects.

```
(!) Unresolved dependencies
https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency
encoding (imported by ../phasetwo-api-client/dist/phasetwo-api-client.es.js, encoding?commonjs-external)
```