### PR TITLE
Tweak rollup.config.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "url": "https://github.com/p2-inc/phasetwo-api-client.git"
   },
   "private": true,
-  "main": "dist/phasetwo-api-client.umd.js",
+  "browser": "dist/phasetwo-api-client.umd.js",
+  "main": "dist/phasetwo-api-client.cjs.js",
   "module": "dist/phasetwo-api-client.es.js",
   "files": [
     "dist"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,19 +3,25 @@ import commonjs from '@rollup/plugin-commonjs';
 import builtins from 'builtin-modules';
 import pkg from './package.json';
 
-export default {
-  input: './src/index.js',
-  output: [
-    {
-      file: pkg.main,
-      format: 'umd', // Universal Module Definition (browser || Node)
+export default [
+  // browser-friendly UMD build
+  {
+    input: 'src/index.js',
+    output: {
+      file: pkg.browser,
+      format: 'umd',
       name: 'PhasetwoApiClient',
     },
-    {
-      file: pkg.module,
-      format: 'es', // ES6 import/export
-    },
-  ],
-  plugins: [resolve(), commonjs()],
-  external: builtins,
-};
+    plugins: [resolve({ browser: true }), commonjs()],
+  },
+
+  // CommonJS (for Node) and ES module (for bundlers) build.
+  {
+    input: 'src/index.js',
+    external: [].concat(builtins, 'isomorphic-unfetch'),
+    output: [
+      { file: pkg.main, format: 'cjs' },
+      { file: pkg.module, format: 'es' },
+    ],
+  },
+];


### PR DESCRIPTION
Create two separate configs, one for the browser that bundles all dependencies, and another for Node and bundlers that relies on dependencies being external.

For the umd build, tell plugin-node-resolve to prefer the `browser` property in package.json when bundling dependencies, which keeps us from packaging Node-specific code from isomorphic-unfetch.